### PR TITLE
fix(config): update default hostname to 'halos'

### DIFF
--- a/config.halos-desktop-halpi2
+++ b/config.halos-desktop-halpi2
@@ -4,4 +4,4 @@ STAGE_LIST="stage0 stage1 stage2 stage3 stage4 stage-halpi2-common stage-halos-b
 DEPLOY_COMPRESSION="xz"
 COMPRESSION_LEVEL=6
 CONTAINER_NAME="pigen_work_halos-desktop-halpi2"
-TARGET_HOSTNAME="halpi2"
+TARGET_HOSTNAME="halos"

--- a/config.halos-desktop-marine-halpi2
+++ b/config.halos-desktop-marine-halpi2
@@ -4,4 +4,4 @@ STAGE_LIST="stage0 stage1 stage2 stage3 stage4 stage-halpi2-common stage-halos-b
 DEPLOY_COMPRESSION="xz"
 COMPRESSION_LEVEL=6
 CONTAINER_NAME="pigen_work_halos-desktop-marine-halpi2"
-TARGET_HOSTNAME="halos-marine"
+TARGET_HOSTNAME="halos"

--- a/config.halos-halpi2
+++ b/config.halos-halpi2
@@ -7,6 +7,6 @@ CONTAINER_NAME="pigen_work_halos-halpi2"
 FIRST_USER_NAME="pi"              # Pre-configured for headless access
 FIRST_USER_PASS="raspberry"       # Default password
 DISABLE_FIRST_BOOT_USER_RENAME="1" # Skip first-boot wizard
-TARGET_HOSTNAME="halpi2"
+TARGET_HOSTNAME="halos"
 WPA_COUNTRY="GB"
 ENABLE_SSH=1

--- a/config.halos-marine-halpi2
+++ b/config.halos-marine-halpi2
@@ -7,6 +7,6 @@ CONTAINER_NAME="pigen_work_halos-marine-halpi2"
 FIRST_USER_NAME="pi"              # Pre-configured for headless access
 FIRST_USER_PASS="raspberry"       # Default password
 DISABLE_FIRST_BOOT_USER_RENAME="1" # Skip first-boot wizard
-TARGET_HOSTNAME="halos-marine"
+TARGET_HOSTNAME="halos"
 WPA_COUNTRY="GB"
 ENABLE_SSH=1


### PR DESCRIPTION
## Summary
- Standardize default hostname to 'halos' across all image configurations

## Changes

Update `TARGET_HOSTNAME` in all HaLOS configuration files:

**Before:**
- Halos-HALPI2: `halpi2`
- Halos-Desktop-HALPI2: `halpi2`
- Halos-Marine-HALPI2: `halos-marine`
- Halos-Desktop-Marine-HALPI2: `halos-marine`

**After:**
- All configs: `halos`

## Motivation

Provides a consistent, generic default hostname across all HaLOS variants:
- Simplifies network configuration and documentation
- Users can customize hostname based on their specific deployment
- No need to differentiate between marine/non-marine in hostname

## Files Changed

- `config.halos-halpi2`
- `config.halos-desktop-halpi2`
- `config.halos-marine-halpi2`
- `config.halos-desktop-marine-halpi2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)