### PR TITLE
Fix desktop autologin reset on first boot by userconf-pi

### DIFF
--- a/stage-halos-desktop/01-set-autologin/01-run.sh
+++ b/stage-halos-desktop/01-set-autologin/01-run.sh
@@ -1,15 +1,27 @@
 #!/bin/bash -e
 
 # Enable graphical desktop autologin for the first user.
-# We configure lightdm directly rather than using raspi-config because
-# raspi-config's do_autologin requires $USER to be set, which it isn't
-# in the pi-gen chroot environment.
+#
+# Two things are needed:
+#
+# 1. Set autologin-user in lightdm.conf (build-time).
+#    The RPi lightdm package normally does this during installation, but we
+#    set it explicitly in case the default changes.
+#
+# 2. Create /var/lib/userconf-pi/autologin marker file.
+#    On first boot, userconf-pi's cancel-rename script checks for this file
+#    to decide between B3 (desktop login) and B4 (desktop autologin). Without
+#    it, cancel-rename resets lightdm to require a login, undoing (1).
+#    The marker is normally created by rename-user, but that only runs when
+#    DISABLE_FIRST_BOOT_USER_RENAME=0.
 
 sed -i "s/^#autologin-user=.*/autologin-user=${FIRST_USER_NAME}/" \
     "${ROOTFS_DIR}/etc/lightdm/lightdm.conf"
 
-# Fail the build if the substitution didn't take effect
 grep -q "^autologin-user=${FIRST_USER_NAME}" "${ROOTFS_DIR}/etc/lightdm/lightdm.conf" || {
     echo "ERROR: Failed to set autologin-user in lightdm.conf" >&2
     exit 1
 }
+
+mkdir -p "${ROOTFS_DIR}/var/lib/userconf-pi"
+touch "${ROOTFS_DIR}/var/lib/userconf-pi/autologin"


### PR DESCRIPTION
## Summary

- The build correctly sets `autologin-user=pi` in lightdm.conf, but on first boot `userconf-pi`'s `cancel-rename` resets it to require a login prompt
- `cancel-rename` checks for `/var/lib/userconf-pi/autologin` to decide between B3 (desktop login) and B4 (desktop autologin) — without the marker, it always chooses B3
- The marker is normally created by `rename-user`, but that only runs when `DISABLE_FIRST_BOOT_USER_RENAME=0` — desktop images with `=1` (AP variant) were missing it
- Fix: create the marker file at build time alongside the lightdm.conf change

## Test plan

- [ ] Build a Desktop-Marine-HALPI2-AP image
- [ ] Flash to device with `user=pi` config
- [ ] Verify device boots to desktop without login prompt
- [ ] Verify `/var/lib/userconf-pi/autologin` is cleaned up after first boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)