### PR TITLE
ci: verify release asset sizes match source after upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,6 +268,7 @@ jobs:
           EOF
 
       - name: 📦 Create draft GitHub Release
+        id: create_release
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -276,3 +277,45 @@ jobs:
           body_path: release_notes.md
           files: all-artifacts/*
           draft: true
+
+      # The upload action can report success while attaching a truncated asset
+      # (observed: two >1 GB images landed ~0.5 GB short with a green tick).
+      # Compare each attached asset's size against its source file and fail the
+      # release if any differ, so corruption never reaches a published image.
+      - name: ✅ Verify attached asset sizes
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dir = 'all-artifacts';
+
+            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ steps.create_release.outputs.id }},
+              per_page: 100,
+            });
+            const attached = new Map(assets.map(a => [a.name, a.size]));
+
+            const mismatches = [];
+            for (const name of fs.readdirSync(dir)) {
+              const local = fs.statSync(path.join(dir, name));
+              if (!local.isFile()) continue;
+              const remote = attached.get(name);
+              if (remote === undefined) {
+                mismatches.push(`${name}: not attached to release`);
+              } else if (remote !== local.size) {
+                mismatches.push(`${name}: source ${local.size} B, attached ${remote} B`);
+              } else {
+                core.info(`✓ ${name} (${local.size} B)`);
+              }
+            }
+
+            if (mismatches.length) {
+              core.setFailed(
+                'Release asset verification failed — attached sizes do not match source:\n' +
+                mismatches.join('\n')
+              );
+            }


### PR DESCRIPTION
## Problem

The `release` job attaches built images with `softprops/action-gh-release@v2`. In the `v2026-06-04.0-1` build, that step logged `✅ Uploaded` for all 11 images, but **two large assets landed truncated on the release**:

| Variant | Built `.img.xz` | Attached asset |
|---|---|---|
| Halos-Desktop-HALPI2 | 1,531,718,477 B (1.53 GB) | **0.98 GB** ❌ |
| Halos-Desktop-Marine-HALPI2-AP | ~1.53 GB | **1.01 GB** ❌ |
| Halos-Desktop-RPI / -Marine-RPI / -Marine-HALPI2 | ~1.5 GB | 1.43–1.50 GB ✓ |

The builds and the workflow artifacts were intact (`download-artifact@v4` SHA256-verified the 1.53 GB sources). The corruption happened purely in the release-upload step, which silently attached short files while reporting success — so a corrupt image would ship to users with nothing flagging it.

## Fix

Add a fail-closed verification step after the release is created: list the attached assets via the API and compare each one's `size` to its source file in `all-artifacts/`. Any mismatch (or missing asset) fails the release job. Size comparison is enough to catch truncation and costs no extra bandwidth (the API returns `size` per asset).

Scope is intentionally minimal — no retry/self-heal — since this is the first observed occurrence; a failed run surfaces it loudly and can be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)